### PR TITLE
Dont fail when no events returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file. For change log formatting, see http://keepachangelog.com/
+
+## Unreleased
+
+Keep future unreleased changes here
+
+## 0.0.5 2016-04-27
+
+### Fixed
+
+- Handle empty events (e.g. on stack deletion) gracefully

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function(cfn, stackName, options) {
 
             if (err) return stream.emit('error', err);
 
-            for (var i = 0; i < data.StackEvents.length; i++) {
+            for (var i = 0; i < (data.StackEvents || []).length; i++) {
                 var event = data.StackEvents[i];
 
                 // Assuming StackEvents are in strictly reverse chronological order.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfn-stack-event-stream",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A readable stream of CloudFormation stack events",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should fix errors we've seen where during stack deletion the last request is sometimes failing.