### PR TITLE
Handle retryable errors from CF

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,11 +25,11 @@ module.exports = function(cfn, stackName, options) {
         cfn.describeStackEvents({StackName: stackName, NextToken: nextToken}, function(err, data) {
             describing = false;
 
-            if (err) {
-                stream.emit('error', err);
-                return err.retryable ? setTimeout(function() {
-                    describeEvents(nextToken);
-                }, 5000) : null;
+            if (err && err.retryable) {
+                stream.emit('managedError', err);
+                return setTimeout(function() { describeEvents(nextToken); }, 5000);
+            } else if (err) {
+                return stream.emit('error', err);
             }
 
             for (var i = 0; i < data.StackEvents.length; i++) {
@@ -65,11 +65,11 @@ module.exports = function(cfn, stackName, options) {
         cfn.describeStacks({StackName: stackName}, function(err, data) {
             describing = false;
 
-            if (err) {
-                stream.emit('error', err);
-                return err.retryable ? setTimeout(function() {
-                    describeStack();
-                }, 5000) : null;
+            if (err && err.retryable) {
+                stream.emit('managedError', err);
+                return setTimeout(function() { describeStack(); }, 5000);
+            } else if (err) {
+                return stream.emit('error', err);
             }
 
             if (/COMPLETE$/.test(data.Stacks[0].StackStatus)) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ module.exports = function(cfn, stackName, options) {
         cfn.describeStackEvents({StackName: stackName, NextToken: nextToken}, function(err, data) {
             describing = false;
 
-            if (err) return stream.emit('error', err);
+            if (err) {
+                stream.emit('error', err);
+                return err.retryable ? setTimeout(function() {
+                    describeEvents(nextToken);
+                }, 5000) : null;
+            }
 
             for (var i = 0; i < data.StackEvents.length; i++) {
                 var event = data.StackEvents[i];
@@ -60,7 +65,12 @@ module.exports = function(cfn, stackName, options) {
         cfn.describeStacks({StackName: stackName}, function(err, data) {
             describing = false;
 
-            if (err) return stream.emit('error', err);
+            if (err) {
+                stream.emit('error', err);
+                return err.retryable ? setTimeout(function() {
+                    describeStack();
+                }, 5000) : null;
+            }
 
             if (/COMPLETE$/.test(data.Stacks[0].StackStatus)) {
                 complete = true;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A readable stream of CloudFormation stack events",
   "main": "index.js",
   "scripts": {
-    "test": "tap test.js"
+    "test": "tape test/*.test.js"
   },
   "author": "John Firebaugh <john@mapbox.com>",
   "license": "ISC",
@@ -12,6 +12,6 @@
     "aws-sdk": "^2.0.0-rc13"
   },
   "devDependencies": {
-    "tap": "^0.4.8"
+    "tape": "~4.4.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,20 +1,19 @@
-var test = require('tap').test;
-var assert = require('assert');
-var Stream = require('./.');
+var test = require('tape');
+var Stream = require('../.');
 var AWS = require('aws-sdk');
 
 var cfn = new AWS.CloudFormation({region: 'us-east-1'});
 
-test('emits an error for a non-existent stack', function (t) {
+test('emits an error for a non-existent stack', function (assert) {
     Stream(cfn, 'cfn-stack-event-stream-test')
         .on('data', function (e) {})
         .on('error', function (err) {
             assert.ok(err);
-            t.end();
+            assert.end();
         });
 });
 
-test('streams events until stack is complete', {timeout: 60000}, function (t) {
+test('streams events until stack is complete', {timeout: 60000}, function (assert) {
     var events = [],
         stackName = 'cfn-stack-event-stream-test-create';
 
@@ -37,13 +36,13 @@ test('streams events until stack is complete', {timeout: 60000}, function (t) {
                         'DELETE_COMPLETE',
                         'ROLLBACK_COMPLETE'
                     ]);
-                    t.end();
+                    assert.end();
                 });
             });
     });
 });
 
-test('streams events during stack deletion', {timeout: 60000}, function (t) {
+test('streams events during stack deletion', {timeout: 60000}, function (assert) {
     var events = [],
         stackName = 'cfn-stack-event-stream-test-delete',
         lastEventId;
@@ -66,9 +65,10 @@ test('streams events during stack deletion', {timeout: 60000}, function (t) {
                         })
                         .on('end', function () {
                             assert.deepEqual(events.map(function (e) { return e.ResourceStatus; }), [
+                                'DELETE_IN_PROGRESS',
                                 'DELETE_COMPLETE'
                             ]);
-                            t.end();
+                            assert.end();
                         });
                 });
             });

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -1,0 +1,64 @@
+var test = require('tape');
+var Stream = require('../.');
+var AWS = require('aws-sdk');
+
+var cfn = new AWS.CloudFormation({region: 'us-east-1'});
+
+test('handles throttle events', {timeout: 60000}, function (assert) {
+    var events = [],
+        errors = [],
+        stackName = 'cfn-stack-event-stream-test-throttle';
+
+    cfn.createStack({
+        StackName: stackName,
+        TemplateBody: JSON.stringify(template)
+    }, function (err) {
+        assert.ifError(err);
+
+        // Hammer CF API to trigger throttling.
+        var interval = setInterval(function() {
+            cfn.describeStacks({StackName: stackName}, function(err, data) {});
+        }, 100);
+
+        Stream(cfn, stackName)
+            .on('error', function(err) {
+                assert.ok(err, 'event on "error"');
+                errors.push(err);
+                // Throttling's been triggered, back off.
+                if (err.code === 'Throttling') {
+                    clearInterval(interval);
+                }
+            })
+            .on('data', function (e) {
+                assert.ok(e, 'event on "data"');
+                events.push(e);
+            })
+            .on('end', function () {
+                cfn.deleteStack({StackName: stackName}, function(err) {
+                    assert.ifError(err);
+                    assert.deepEqual(events.map(function (e) { return e.ResourceStatus; }), [
+                        'CREATE_IN_PROGRESS',
+                        'CREATE_FAILED',
+                        'ROLLBACK_IN_PROGRESS',
+                        'DELETE_COMPLETE',
+                        'ROLLBACK_COMPLETE'
+                    ]);
+                    assert.equal(errors.length > 0, true);
+                    assert.end();
+                });
+            });
+    });
+});
+
+var template = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "cfn-stack-event-stream-test",
+    "Resources": {
+        "Test": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+
+            }
+        }
+    }
+};

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -21,8 +21,8 @@ test('handles throttle events', {timeout: 60000}, function (assert) {
         }, 100);
 
         Stream(cfn, stackName)
-            .on('managedError', function(err) {
-                assert.ok(err, 'managedError');
+            .on('retry', function(err) {
+                assert.ok(err, 'retry');
                 managed.push(err);
                 clearInterval(interval);
             })


### PR DESCRIPTION
- Retries describeStackEvents, describeStacks calls if CF hands us a RateExceeded or any other retryable error after a 5s pause.
- Adds a test for this scenario by launching a stack, starting a stack event stream, and then hammering the CF API until the stream gracefully handles a throttling event.
- Includes https://github.com/mapbox/cfn-stack-event-stream/pull/4.

This module doesn't have CI tests but running these locally with sufficient AWS permissions should allow you to reproduce the appropriate test behavior.

cc @jfirebaugh @emilymcafee 