### PR TITLE
Limit stream backfill to first user-initiated event

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,14 @@ module.exports = function(cfn, stackName, options) {
 
                 events.push(event);
                 seen[event.EventId] = true;
+
+                // If we reach a user initiated event assume this event is the
+                // initiating event the caller intends to monitor.
+                if (event.LogicalResourceId === stackName &&
+                    event.ResourceType === 'AWS::CloudFormation::Stack' &&
+                    event.ResourceStatusReason === 'User Initiated') {
+                    break;
+                }
             }
 
             if (i === data.StackEvents.length && data.NextToken) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,61 +13,117 @@ test('emits an error for a non-existent stack', function (assert) {
         });
 });
 
-test('streams events until stack is complete', {timeout: 60000}, function (assert) {
-    var events = [],
-        stackName = 'cfn-stack-event-stream-test-create';
+test('streams events until stack is complete', {timeout: 120000}, function (assert) {
+    var stackName = 'cfn-stack-event-stream-test-create';
 
     cfn.createStack({
         StackName: stackName,
         TemplateBody: JSON.stringify(template)
     }, function (err) {
-        assert.ifError(err);
+        if (err) {
+            assert.ifError(err);
+            assert.end();
+            return;
+        }
+        var events = [
+            'CREATE_IN_PROGRESS AWS::CloudFormation::Stack',
+            'CREATE_IN_PROGRESS AWS::SNS::Topic',
+            'CREATE_IN_PROGRESS AWS::SNS::Topic',
+            'CREATE_COMPLETE AWS::SNS::Topic',
+            'CREATE_COMPLETE AWS::CloudFormation::Stack'
+        ];
         Stream(cfn, stackName)
             .on('data', function (e) {
-                events.push(e);
+                assert.equal(events[0], e.ResourceStatus + ' ' + e.ResourceType, e.ResourceStatus + ' ' + e.ResourceType);
+                events.shift();
             })
             .on('end', function () {
-                cfn.deleteStack({StackName: stackName}, function(err) {
-                    assert.ifError(err);
-                    assert.deepEqual(events.map(function (e) { return e.ResourceStatus; }), [
-                        'CREATE_IN_PROGRESS',
-                        'CREATE_FAILED',
-                        'ROLLBACK_IN_PROGRESS',
-                        'DELETE_COMPLETE',
-                        'ROLLBACK_COMPLETE'
-                    ]);
-                    assert.end();
-                });
+                updateStack();
             });
     });
+
+    function updateStack() {
+        // Modify template for update.
+        var templateUpdated = JSON.parse(JSON.stringify(template));
+        templateUpdated.Resources.NewTopic = {
+            "Type": "AWS::SNS::Topic",
+            "Properties" : {
+                "DisplayName": "Topic2"
+            }
+        };
+
+        cfn.updateStack({
+            StackName: stackName,
+            TemplateBody: JSON.stringify(templateUpdated)
+        }, function (err) {
+            if (err) {
+                assert.ifError(err);
+                assert.end();
+                return;
+            }
+            var events = [
+                'UPDATE_IN_PROGRESS AWS::CloudFormation::Stack',
+                'CREATE_IN_PROGRESS AWS::SNS::Topic',
+                'CREATE_IN_PROGRESS AWS::SNS::Topic',
+                'CREATE_COMPLETE AWS::SNS::Topic',
+                'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS AWS::CloudFormation::Stack',
+                'UPDATE_COMPLETE AWS::CloudFormation::Stack'
+            ];
+            Stream(cfn, stackName)
+                .on('data', function (e) {
+                    assert.equal(events[0], e.ResourceStatus + ' ' + e.ResourceType, e.ResourceStatus + ' ' + e.ResourceType);
+                    events.shift();
+                })
+                .on('end', function () {
+                    deleteStack();
+                });
+        });
+    }
+
+    function deleteStack() {
+        cfn.deleteStack({StackName: stackName}, function(err) {
+            assert.ifError(err);
+            assert.end();
+        });
+    }
 });
 
 test('streams events during stack deletion', {timeout: 60000}, function (assert) {
-    var events = [],
-        stackName = 'cfn-stack-event-stream-test-delete',
+    var stackName = 'cfn-stack-event-stream-test-delete',
         lastEventId;
 
     cfn.createStack({
         StackName: stackName,
         TemplateBody: JSON.stringify(template)
     }, function (err, stack) {
-        assert.ifError(err);
+        if (err) {
+            assert.ifError(err);
+            assert.end();
+            return;
+        }
         Stream(cfn, stackName)
             .on('data', function (e) {
                 lastEventId = e.EventId;
             })
             .on('end', function () {
                 cfn.deleteStack({StackName: stackName}, function(err) {
-                    assert.ifError(err);
+                    if (err) {
+                        assert.ifError(err);
+                        assert.end();
+                        return;
+                    }
+                    var events = [
+                        'DELETE_IN_PROGRESS AWS::CloudFormation::Stack',
+                        'DELETE_IN_PROGRESS AWS::SNS::Topic',
+                        'DELETE_COMPLETE AWS::SNS::Topic',
+                        'DELETE_COMPLETE AWS::CloudFormation::Stack'
+                    ];
                     Stream(cfn, stack.StackId, {lastEventId: lastEventId})
                         .on('data', function (e) {
-                            events.push(e);
+                            assert.equal(events[0], e.ResourceStatus + ' ' + e.ResourceType, e.ResourceStatus + ' ' + e.ResourceType);
+                            events.shift();
                         })
                         .on('end', function () {
-                            assert.deepEqual(events.map(function (e) { return e.ResourceStatus; }), [
-                                'DELETE_IN_PROGRESS',
-                                'DELETE_COMPLETE'
-                            ]);
                             assert.end();
                         });
                 });
@@ -78,12 +134,20 @@ test('streams events during stack deletion', {timeout: 60000}, function (assert)
 var template = {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "cfn-stack-event-stream-test",
+    "Parameters": {
+        "TestParameter": {
+            "Description": "A parameter for testing",
+            "Type": "String",
+            "Default": "TestParameterValue"
+        }
+    },
     "Resources": {
-        "Test": {
-            "Type": "AWS::AutoScaling::LaunchConfiguration",
-            "Properties": {
-
+        "TestTopic" : {
+            "Type": "AWS::SNS::Topic",
+            "Properties" : {
+                "DisplayName": { "Ref": "TestParameter" }
             }
         }
     }
 };
+


### PR DESCRIPTION
Turns out the aws-sdk update included some unexpected surprises. The CF event stream can now be paged back seemingly indefinitely, making each event stream a full history of the stack (and totally spammy).

This is cool but not the previous behavior of this module -- we need to stop backfilling events when we hit the last user-initiated stack action.

- Revamps tests to create a real resource and assert about more specific events,
- Stops backfilling when it sees the last `User Initiated` CF stack event

Tested + ready -- will merge to make https://github.com/mapbox/cfn-stack-event-stream/pull/10 actually usable.