### PR TITLE
Describe stacks by ARN

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(cfn, stackName, options) {
         pollInterval = options.pollInterval || 1000,
         describing = false,
         complete = false,
-        stackId = false,
+        stackId = stackName,
         seen = {},
         events = [],
         push = stream.push.bind(stream);
@@ -72,7 +72,7 @@ module.exports = function(cfn, stackName, options) {
 
     function describeStack() {
         describing = true;
-        cfn.describeStacks({StackName: stackName}, function(err, data) {
+        cfn.describeStacks({StackName: stackId}, function(err, data) {
             describing = false;
 
             if (err) return stream.emit('error', err);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = function(cfn, stackName, options) {
         pollInterval = options.pollInterval || 1000,
         describing = false,
         complete = false,
+        stackId = false,
         seen = {},
         events = [],
         push = stream.push.bind(stream);
@@ -17,12 +18,14 @@ module.exports = function(cfn, stackName, options) {
 
     stream._read = function() {
         if (describing || complete) return;
-        describeEvents();
+        describeStack();
     };
 
     function describeEvents(nextToken) {
         describing = true;
-        cfn.describeStackEvents({StackName: stackName, NextToken: nextToken}, function(err, data) {
+        // Describe stacks using stackId (ARN) as CF stacks are actually
+        // not unique by name.
+        cfn.describeStackEvents({StackName: stackId, NextToken: nextToken}, function(err, data) {
             describing = false;
 
             if (err) return stream.emit('error', err);
@@ -73,6 +76,9 @@ module.exports = function(cfn, stackName, options) {
             describing = false;
 
             if (err) return stream.emit('error', err);
+            if (!data.Stacks.length) return stream.emit('error', new Error('Could not describe stack: ' + stackName));
+
+            stackId = data.Stacks[0].StackId;
 
             if (/COMPLETE$/.test(data.Stacks[0].StackStatus)) {
                 complete = true;


### PR DESCRIPTION
Background:

- The CFN API accepts either StackName or StackId (ARN) for these describe calls.
- It turns out you pretty much always want the `StackId` if you can as there can be multiple stacks with the same name (e.g. `stack-a` that's in state `DELETED` and `stack-a` that's in state `UPDATE_COMPLETE`).
- You can't describe a deleted stack by StackName.

This PR adjusts the stream to make a describestack call first, and then use the ARN from that point on in subsequent calls.

cc @rclark 